### PR TITLE
Pass locked field for signer_tabs.

### DIFF
--- a/lib/docusign_rest/client.rb
+++ b/lib/docusign_rest/client.rb
@@ -206,7 +206,8 @@ module DocusignRest
           'name' => tab[:name],
           'value' => tab[:value],
           'documentId' => tab[:document_id],
-          'selected' => tab[:selected]
+          'selected' => tab[:selected],
+          'locked' => tab[:locked]
         }
       end
     end

--- a/lib/docusign_rest/version.rb
+++ b/lib/docusign_rest/version.rb
@@ -1,3 +1,3 @@
 module DocusignRest
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end


### PR DESCRIPTION
Passing the locked field in the signer tabs will prevent the field from being edited.

Tested it and it works. The DS fields are read only.
